### PR TITLE
Removed commit message from calc-stats function

### DIFF
--- a/pkg/analyzer/commit_history.go
+++ b/pkg/analyzer/commit_history.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"strings"
 
 	"github.com/go-git/go-git/v5"                 // Core Go-git library
 	"github.com/go-git/go-git/v5/plumbing/object"  // Used for commit objects
@@ -35,12 +34,7 @@ func AnalyzeCommitHistory(repoPath string) {
 
 	fmt.Println("Commit history analysis:")
 	err = commitIter.ForEach(func(c *object.Commit) error {
-		// Trim the commit message to remove leading/trailing whitespace
-		trimmedMessage := strings.TrimSpace(c.Message)
-
-		// Print each commit's message and author
-		fmt.Printf("Author: %s Commit Message:%s\n", c.Author.Name,trimmedMessage)
-
+		
 		// Increment commit count for the author
 		commitCounts[c.Author.Name]++
 		commitCount++


### PR DESCRIPTION
What does this PR do ?

This PR resolves the issue of unnecessary commit messages when executing `vc-analyze calc-stats /path `

Fixes #23 

Before: 
<img width="1447" alt="Screenshot 2024-10-11 at 2 43 20 PM" src="https://github.com/user-attachments/assets/c01b9123-be71-4281-9821-fdadd3cf986d">
After:
<img width="1708" alt="Screenshot 2024-10-11 at 2 42 58 PM" src="https://github.com/user-attachments/assets/89c674e2-b309-4ff2-b794-84279d419850">

