### PR TITLE
Add flags to specify functionality in calc-stats subcommand

### DIFF
--- a/cmd/subcommands/calc_stats.go
+++ b/cmd/subcommands/calc_stats.go
@@ -1,40 +1,62 @@
 package subcommands
 
 import (
-    "errors"
-    "fmt"
-    "os"
+	"errors"
+	"fmt"
+	"os"
 
-    "github.com/spf13/cobra"
-    "github.com/MakeNowJust/heredoc/v2"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/spf13/cobra"
 
-    "github.com/adigulalkari/VC-Analyzer/pkg/analyzer" 
+	"github.com/adigulalkari/VC-Analyzer/pkg/analyzer"
 )
 
-var CalcStatsCmd = &cobra.Command{ 
-    Use:     "calc-stats <detail>",
-    Short:   "Calculate the number of commits for the local repo",
-    Example: heredoc.Doc(`
-        Calculate the number of commits for the local repo
-        $ vc-analyze calc-stats path/to/local/repo
+var (
+	authorStats bool
+	commitSize  bool
+)
+
+var CalcStatsCmd = &cobra.Command{
+	Use:   "calc-stats <path/to/repo>",
+	Short: "Calculate statistics for the local repo",
+	Long:  `This command allows you to calculate various statistics for a local Git repository, including author statistics and commit size statistics.`,
+	Example: heredoc.Doc(`
+        # Calculate author statistics
+        $ vc-analyze calc-stats --author-stats path/to/local/repo
+
+        # Calculate commit size statistics
+        $ vc-analyze calc-stats --commit-size path/to/local/repo
     `),
-    Args: func(cmd *cobra.Command, args []string) error {
-        if len(args) < 1 {
-            return errors.New("requires a detail argument")
-        }
-        return nil
-    },
-    RunE: func(cmd *cobra.Command, args []string) error {
-        repoPath := args[0] // Get the repository path from the arguments
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("requires a path to the repository")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repoPath := args[0] // Get the repository path from the arguments
 
-        // Check if the repository exists (optional)
-        if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-            return fmt.Errorf("repository path does not exist: %s", repoPath)
-        }
+		// Check if the repository exists (optional)
+		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+			return fmt.Errorf("repository path does not exist: %s", repoPath)
+		}
 
-        // Call the AnalyzeCommitHistory function
-        analyzer.AnalyzeCommitHistory(repoPath)
+		// Check which flag is set and call the appropriate function
+		if authorStats {
+			// Call a function to calculate author statistics
+			analyzer.AnalyzeCommitHistory(repoPath)
+		} else if commitSize {
+			// Call a function to calculate commit size statistics
+			analyzer.AnalyzeCommitSize(repoPath)
+		} else {
+			return errors.New("no valid flag provided, use --author-stats or --commit-size")
+		}
 
-        return nil
-    },
+		return nil
+	},
+}
+
+func init() {
+    CalcStatsCmd.Flags().BoolVar(&authorStats, "author-stats", false, "Calculate statistics for each author")
+    CalcStatsCmd.Flags().BoolVar(&commitSize, "commit-size", false, "Calculate the size of commits")
 }

--- a/pkg/analyzer/commit_history.go
+++ b/pkg/analyzer/commit_history.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/go-git/go-git/v5"                 // Core Go-git library
-	"github.com/go-git/go-git/v5/plumbing/object"  // Used for commit objects
+	"github.com/go-git/go-git/v5/plumbing/object" // Used for commit objects
 )
 
 // AnalyzeCommitHistory analyzes and prints commit history of the given repository
@@ -34,7 +34,6 @@ func AnalyzeCommitHistory(repoPath string) {
 
 	fmt.Println("Commit history analysis:")
 	err = commitIter.ForEach(func(c *object.Commit) error {
-		
 		// Increment commit count for the author
 		commitCounts[c.Author.Name]++
 		commitCount++
@@ -70,4 +69,41 @@ func AnalyzeCommitHistory(repoPath string) {
 	for _, ac := range authorCommits {
 		fmt.Printf("%s: %d commits\n", ac.Author, ac.Count)
 	}
+}
+
+func AnalyzeCommitSize(repoPath string) {
+	repo, err := git.PlainOpen(repoPath)
+	if err != nil {
+		log.Fatalf("Error opening repository: %v", err)
+	}
+
+	//Get the HEAD reference
+	ref, err := repo.Head()
+	if err != nil {
+		log.Fatalf("Error getting HEAD reference: %v", err)
+	}
+
+	//Iterate over the commit history starting from HEAD
+	commitIter, err := repo.Log(&git.LogOptions{From: ref.Hash()})
+	if err != nil {
+		log.Fatalf("Error getting commit log: %v", err)
+	}
+
+	totalSize := 0
+	commitCount := 0
+
+	err = commitIter.ForEach(func(c *object.Commit) error {
+		totalSize += len(c.Message) // Approximate commit size as the message length
+		commitCount++
+		return nil
+	})
+
+	if err != nil {
+		log.Fatalf("Error iterating over commits: %v", err)
+	}
+
+	// Print commit size statistics
+	fmt.Printf("\nTotal number of commits: %d\n", commitCount)
+	fmt.Printf("Total commit message size: %d bytes\n", totalSize)
+	fmt.Printf("Average commit size: %.2f bytes\n", float64(totalSize)/float64(commitCount))
 }

--- a/pkg/analyzer/commit_history.go
+++ b/pkg/analyzer/commit_history.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"strings"
 
 	"github.com/go-git/go-git/v5"                 // Core Go-git library
 	"github.com/go-git/go-git/v5/plumbing/object"  // Used for commit objects
@@ -35,12 +34,7 @@ func AnalyzeCommitHistory(repoPath string) {
 
 	fmt.Println("Commit history analysis:")
 	err = commitIter.ForEach(func(c *object.Commit) error {
-		// Trim the commit message to remove leading/trailing whitespace
-		trimmedMessage := strings.TrimSpace(c.Message)
-
-		// Print each commit's message and author
-		fmt.Printf("Author: %s Commit Message:%s\n", c.Author.Name,trimmedMessage)
-
+		
 		// Increment commit count for the author
 		commitCounts[c.Author.Name]++
 		commitCount++


### PR DESCRIPTION
# What does this PR do?

This PR enhances the calc-stats subcommand by adding flags to specify the exact functionality required from the user. The new flags include:

	•	--author-stats: for calculating statistics based on author commit history.
	•	--commit-size: for analyzing commit sizes within the repository.
	
Fixes #25 


<img width="1158" alt="Screenshot 2024-10-11 at 4 23 30 PM" src="https://github.com/user-attachments/assets/92bfa170-7eab-4695-b574-43796ed258f5">


----------------

<img width="1655" alt="Screenshot 2024-10-11 at 4 17 52 PM" src="https://github.com/user-attachments/assets/4862e0e5-71f1-4559-a744-673a7e6320c7">

